### PR TITLE
Pull Request: Fix create_keyshot_env_plist function to handle missing directory and file

### DIFF
--- a/install_deadline_cloud_keyshot_macos.sh
+++ b/install_deadline_cloud_keyshot_macos.sh
@@ -406,10 +406,21 @@ setup_environment_variables() {
 # Function to create a plist file for KeyShot environment variables
 create_keyshot_env_plist() {
     echo -e "${TEXT_COLOR}#${RESET} Calling ${FUNCTION}create_keyshot_env_plist${RESET} function..."
-    local plist_path="$HOME/Library/LaunchAgents/com.keyshot.environment.plist"
+    local plist_dir="$HOME/Library/LaunchAgents"
+    local plist_path="$plist_dir/com.keyshot.environment.plist"
     local keyshot_app="/Applications/$KEYSHOT_FOLDER.app"
 
+    # Check if the LaunchAgents directory exists, create if it doesn't
+    if [ ! -d "$plist_dir" ]; then
+        echo -e "${WARNING}#${RESET} LaunchAgents directory does not exist. Creating..."
+        if ! mkdir -p "$plist_dir"; then
+            echo -e "${ERROR}#${RESET} Failed to create LaunchAgents directory. Please check your permissions."
+            abort
+        fi
+    fi
+
     # Create the plist file
+    echo -e "${WARNING}#${RESET} Creating plist file..."
     cat << EOF > "$plist_path"
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -433,6 +444,12 @@ create_keyshot_env_plist() {
 </dict>
 </plist>
 EOF
+
+    # Check if the file was created successfully
+    if [ ! -f "$plist_path" ]; then
+        echo -e "${ERROR}#${RESET} Failed to create plist file. Please check your permissions."
+        abort
+    fi
 
     # Set appropriate permissions for the plist file
     chmod 644 "$plist_path"


### PR DESCRIPTION
# Pull Request: Fix create_keyshot_env_plist function to handle missing directory and file

## Description
This PR addresses the issue where the `create_keyshot_env_plist` function fails to create the necessary directory and file for the KeyShot environment plist. The function has been modified to check for the existence of the LaunchAgents directory and the plist file, creating them if they don't exist.

## Changes Made
1. Added a check for the existence of the LaunchAgents directory.
2. Implemented directory creation if it doesn't exist.
3. Added a check to ensure the plist file was created successfully.
4. Improved error handling and messaging throughout the function.

## Testing Done
- Tested the script on a clean macOS environment where the LaunchAgents directory did not exist.
- Verified that the script successfully creates both the directory and the plist file.
- Confirmed that the plist file is properly loaded after creation.

## Related Issue
Fixes #4 